### PR TITLE
Feature title

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ const MSG_BEFORE_DETACH = new Message('before-detach');
 const WIDGET_CLASS = 'p-Widget';
 
 /**
- * The modifier class name added to hidden widgets.
+ * The class name added to hidden widgets.
  */
 const HIDDEN_CLASS = 'p-mod-hidden';
 
@@ -196,20 +196,57 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    * A property descriptor for the widget title.
    *
    * #### Notes
+   * This property has no direct effect on the behavior of the widget.
+   * It is intended to be consumed by container widgets when displaying
+   * the widget in a context where a title is appropriate.
+   *
+   * The value is the display text to use for the widget title.
+   *
+   * The default value is an empty string.
+   *
+   * **See also:** [[title]], [[icon]]
    */
   static titleProperty = new Property<Widget, string>({
     value: '',
   });
 
   /**
-   * A property descriptor
+   * A property descriptor for the widget icon class.
+   *
+   * #### Notes
+   * This property has no direct effect on the behavior of the widget.
+   * It is intended to be consumed by container widgets when displaying
+   * the widget in a context where an icon is appropriate.
+   *
+   * The value is the *class name* to be added to the DOM node which
+   * displays the actual icon.
+   *
+   * The default value is an empty string.
+   *
+   * **See also:** [[icon]], [[title]]
    */
   static iconProperty = new Property<Widget, string>({
     value: '',
   });
 
   /**
+   * A property descriptor which controls the widget closable state.
    *
+   * #### Notes
+   * This property controls whether the widget can be closed via user
+   * interaction with the UI.
+   *
+   * This property has no direct effect on the behavior of the widget.
+   * It is intended to be consumed by container widgets when deciding
+   * whether to support a user close action for the widget.
+   *
+   * This property **does not** affect the logic of the default close
+   * handler, and the widget can still be closed programmatically even
+   * if this value is `false`.
+   *
+   * The default value is `true`.
+   *
+   * **See also:** [[closable]], [[close]]
    */
   static closableProperty = new Property<Widget, boolean>({
     value: true,
@@ -332,42 +369,60 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   }
 
   /**
+   * Get the title for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[titleProperty]].
    */
   get title(): string {
     return Widget.titleProperty.get(this);
   }
 
   /**
+   * Set the title for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[titleProperty]].
    */
   set title(value: string) {
     Widget.titleProperty.set(this, value);
   }
 
   /**
+   * Get the icon class name for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[iconProperty]].
    */
   get icon(): string {
     return Widget.iconProperty.get(this);
   }
 
   /**
+   * Set the icon class name for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[iconProperty]].
    */
   set icon(value: string) {
     Widget.iconProperty.set(this, value);
   }
 
   /**
+   * Get the closable state for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[closableProperty]].
    */
   get closable(): boolean {
     return Widget.closableProperty.get(this);
   }
 
   /**
+   * Set the closable state for the widget.
    *
+   * #### Notes
+   * This is a pure delegate to the [[closableProperty]].
    */
   set closable(value: boolean) {
     Widget.closableProperty.set(this, value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,29 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   });
 
   /**
+   * A property descriptor for the widget title.
+   *
+   * #### Notes
+   */
+  static titleProperty = new Property<Widget, string>({
+    value: '',
+  });
+
+  /**
+   * A property descriptor
+   */
+  static iconProperty = new Property<Widget, string>({
+    value: '',
+  });
+
+  /**
+   *
+   */
+  static closableProperty = new Property<Widget, boolean>({
+    value: true,
+  });
+
+  /**
    * Construct a new widget.
    */
   constructor() {
@@ -306,6 +329,48 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    */
   set hidden(value: boolean) {
     Widget.hiddenProperty.set(this, value);
+  }
+
+  /**
+   *
+   */
+  get title(): string {
+    return Widget.titleProperty.get(this);
+  }
+
+  /**
+   *
+   */
+  set title(value: string) {
+    Widget.titleProperty.set(this, value);
+  }
+
+  /**
+   *
+   */
+  get icon(): string {
+    return Widget.iconProperty.get(this);
+  }
+
+  /**
+   *
+   */
+  set icon(value: string) {
+    Widget.iconProperty.set(this, value);
+  }
+
+  /**
+   *
+   */
+  get closable(): boolean {
+    return Widget.closableProperty.get(this);
+  }
+
+  /**
+   *
+   */
+  set closable(value: boolean) {
+    Widget.closableProperty.set(this, value);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,7 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   });
 
   /**
-   * A property descriptor for the widget icon class.
+   * A property descriptor for the widget title icon class.
    *
    * #### Notes
    * This property has no direct effect on the behavior of the widget.
@@ -224,37 +224,31 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    * the widget in a context where an icon is appropriate.
    *
    * The value is the *class name* to be added to the DOM node which
-   * displays the actual icon.
+   * displays the actual icon. Multiple class names can be separated
+   * with whitespace.
    *
    * The default value is an empty string.
    *
-   * **See also:** [[icon]]
+   * **See also:** [[titleIcon]]
    */
-  static iconProperty = new Property<Widget, string>({
+  static titleIconProperty = new Property<Widget, string>({
     value: '',
   });
 
   /**
-   * A property descriptor which controls the widget closable state.
+   * A property descriptor which controls the widget closable hint.
    *
    * #### Notes
-   * This property controls whether the widget can be closed via user
-   * interaction with the UI.
-   *
    * This property has no direct effect on the behavior of the widget.
    * It is intended to be consumed by container widgets when deciding
-   * whether to support a user close action for the widget.
+   * whether to display a close indicator to the user.
    *
-   * This property **does not** affect the logic of the default close
-   * handler, and the widget can still be closed programmatically even
-   * if this value is `false`.
+   * The default value is `false`.
    *
-   * The default value is `true`.
-   *
-   * **See also:** [[closable]], [[close]]
+   * **See also:** [[closableHint]], [[close]]
    */
-  static closableProperty = new Property<Widget, boolean>({
-    value: true,
+  static closableHintProperty = new Property<Widget, boolean>({
+    value: false,
   });
 
   /**
@@ -394,43 +388,43 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   }
 
   /**
-   * Get the icon class name for the widget.
+   * Get the title icon class name for the widget.
    *
    * #### Notes
-   * This is a pure delegate to the [[iconProperty]].
+   * This is a pure delegate to the [[titleIconProperty]].
    */
-  get icon(): string {
-    return Widget.iconProperty.get(this);
+  get titleIcon(): string {
+    return Widget.titleIconProperty.get(this);
   }
 
   /**
-   * Set the icon class name for the widget.
+   * Set the title icon class name for the widget.
    *
    * #### Notes
-   * This is a pure delegate to the [[iconProperty]].
+   * This is a pure delegate to the [[titleIconProperty]].
    */
-  set icon(value: string) {
-    Widget.iconProperty.set(this, value);
+  set titleIcon(value: string) {
+    Widget.titleIconProperty.set(this, value);
   }
 
   /**
-   * Get the closable state for the widget.
+   * Get the closable hint for the widget.
    *
    * #### Notes
-   * This is a pure delegate to the [[closableProperty]].
+   * This is a pure delegate to the [[closableHintProperty]].
    */
-  get closable(): boolean {
-    return Widget.closableProperty.get(this);
+  get closableHint(): boolean {
+    return Widget.closableHintProperty.get(this);
   }
 
   /**
-   * Set the closable state for the widget.
+   * Set the closable hint for the widget.
    *
    * #### Notes
-   * This is a pure delegate to the [[closableProperty]].
+   * This is a pure delegate to the [[closableHintProperty]].
    */
-  set closable(value: boolean) {
-    Widget.closableProperty.set(this, value);
+  set closableHint(value: boolean) {
+    Widget.closableHintProperty.set(this, value);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,22 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   });
 
   /**
+   * A property descriptor for the widget title editable hint.
+   *
+   * #### Notes
+   * This property has no direct effect on the behavior of the widget.
+   * It is intended to be consumed by container widgets when deciding
+   * whether to allow the user to edit the widget title.
+   *
+   * The default value is `false`.
+   *
+   * **See also:** [[titleEditableHint]], [[titleProperty]]
+   */
+  static titleEditableHintProperty = new Property<Widget, boolean>({
+    value: false,
+  });
+
+  /**
    * A property descriptor which controls the widget closable hint.
    *
    * #### Notes
@@ -385,6 +401,26 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    */
   set title(value: string) {
     Widget.titleProperty.set(this, value);
+  }
+
+  /**
+   * Get the title editable hint for the widget.
+   *
+   * #### Notes
+   * This is a pure delegate to the [[titleEditableHintProperty]].
+   */
+  get titleEditableHint(): boolean {
+    return Widget.titleEditableHintProperty.get(this);
+  }
+
+  /**
+   * Set the title editable hint for the widget.
+   *
+   * #### Notes
+   * This is a pure delegate to the [[titleEditableHintProperty]].
+   */
+  set titleEditableHint(value: boolean) {
+    Widget.titleEditableHintProperty.set(this, value);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,9 +202,14 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    *
    * The value is the display text to use for the widget title.
    *
+   * Code should not modify this property directly in response to user
+   * input events. Instead, a [[ChangeTitleMessage]] should be sent to
+   * the widget, which allows the widget an opportunity to update its
+   * internal state before updating its public property.
+   *
    * The default value is an empty string.
    *
-   * **See also:** [[title]], [[icon]]
+   * **See also:** [[title]], [[ChangeTitleMessage]], [[onChangeTitle]]
    */
   static titleProperty = new Property<Widget, string>({
     value: '',
@@ -223,7 +228,7 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    *
    * The default value is an empty string.
    *
-   * **See also:** [[icon]], [[title]]
+   * **See also:** [[icon]]
    */
   static iconProperty = new Property<Widget, string>({
     value: '',
@@ -967,6 +972,9 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
     case 'close-request':
       this.onCloseRequest(msg);
       break;
+    case 'change-title':
+      this.onChangeTitle(<ChangeTitleMessage>msg);
+      break;
     }
   }
 
@@ -1098,6 +1106,20 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
     } else if (this.isAttached) {
       detachWidget(this);
     }
+  }
+
+  /**
+   * A message handler invoked on a `'change-title'` message.
+   *
+   * #### Notes
+   * The default implementation of this handler will change the `title`
+   * of the widget to the title provided by the message. Subclasses may
+   * reimplement this handler for custom title change behavior.
+   *
+   * **See also:** [[titleProperty]]
+   */
+  protected onChangeTitle(msg: ChangeTitleMessage): void {
+    this.title = msg.title;
   }
 
   /**
@@ -1286,7 +1308,7 @@ class ChildMessage extends Message {
 
 
 /**
- * A message class for 'resize' messages.
+ * A message class for `'resize'` messages.
  */
 export
 class ResizeMessage extends Message {
@@ -1336,6 +1358,40 @@ class ResizeMessage extends Message {
 
   private _width: number;
   private _height: number;
+}
+
+
+/**
+ * A message class for `'change-title'` messages.
+ *
+ * Messages of this type are used to change the `title` property of a
+ * widget in response to a user input event.
+ *
+ * **See also:** [[titleProperty]], [[onChangeTitle]]
+ */
+export
+class ChangeTitleMessage extends Message {
+  /**
+   * Construct a new change title message.
+   *
+   * @param title - The title to use for the widget.
+   */
+  constructor(title: string) {
+    super('change-title');
+    this._title = title;
+  }
+
+  /**
+   * The title for the widget.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  get title(): string {
+    return this._title;
+  }
+
+  private _title: string;
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,26 +404,6 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
   }
 
   /**
-   * Get the title editable hint for the widget.
-   *
-   * #### Notes
-   * This is a pure delegate to the [[titleEditableHintProperty]].
-   */
-  get titleEditableHint(): boolean {
-    return Widget.titleEditableHintProperty.get(this);
-  }
-
-  /**
-   * Set the title editable hint for the widget.
-   *
-   * #### Notes
-   * This is a pure delegate to the [[titleEditableHintProperty]].
-   */
-  set titleEditableHint(value: boolean) {
-    Widget.titleEditableHintProperty.set(this, value);
-  }
-
-  /**
    * Get the title icon class name for the widget.
    *
    * #### Notes
@@ -441,6 +421,26 @@ class Widget extends NodeWrapper implements IDisposable, IMessageHandler {
    */
   set titleIcon(value: string) {
     Widget.titleIconProperty.set(this, value);
+  }
+
+  /**
+   * Get the title editable hint for the widget.
+   *
+   * #### Notes
+   * This is a pure delegate to the [[titleEditableHintProperty]].
+   */
+  get titleEditableHint(): boolean {
+    return Widget.titleEditableHintProperty.get(this);
+  }
+
+  /**
+   * Set the title editable hint for the widget.
+   *
+   * #### Notes
+   * This is a pure delegate to the [[titleEditableHintProperty]].
+   */
+  set titleEditableHint(value: boolean) {
+    Widget.titleEditableHintProperty.set(this, value);
   }
 
   /**

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -23,8 +23,9 @@ import {
 
 import {
   MSG_AFTER_ATTACH, MSG_AFTER_SHOW, MSG_BEFORE_DETACH, MSG_BEFORE_HIDE,
-  MSG_CLOSE_REQUEST, MSG_LAYOUT_REQUEST, MSG_UPDATE_REQUEST, ChildMessage,
-  ResizeMessage, Widget, attachWidget, detachWidget
+  MSG_CLOSE_REQUEST, MSG_LAYOUT_REQUEST, MSG_UPDATE_REQUEST,
+  ChangeTitleMessage, ChildMessage, ResizeMessage, Widget, attachWidget,
+  detachWidget
 } from '../../lib/index';
 
 import './index.css';
@@ -57,82 +58,88 @@ class VerboseWidget extends Widget {
     if (children) children.forEach(child => this.addChild(child));
   }
 
-  protected onChildAdded(msg: ChildMessage) {
+  protected onChildAdded(msg: ChildMessage): void {
     super.onChildAdded(msg);
     this.messages.push(msg);
     this.methods.push('onChildAdded');
   }
 
-  protected onChildRemoved(msg: ChildMessage) {
+  protected onChildRemoved(msg: ChildMessage): void {
     super.onChildRemoved(msg);
     this.messages.push(msg);
     this.methods.push('onChildRemoved');
   }
 
-  protected onChildMoved(msg: ChildMessage) {
+  protected onChildMoved(msg: ChildMessage): void {
     super.onChildMoved(msg);
     this.messages.push(msg);
     this.methods.push('onChildMoved');
   }
 
-  protected onResize(msg: ResizeMessage) {
+  protected onResize(msg: ResizeMessage): void {
     super.onResize(msg);
     this.messages.push(msg);
     this.methods.push('onResize');
   }
 
-  protected onUpdateRequest(msg: Message) {
+  protected onUpdateRequest(msg: Message): void {
     super.onUpdateRequest(msg);
     this.messages.push(msg);
     this.methods.push('onUpdateRequest');
   }
 
-  protected onLayoutRequest(msg: Message) {
+  protected onLayoutRequest(msg: Message): void {
     super.onLayoutRequest(msg);
     this.messages.push(msg);
     this.methods.push('onLayoutRequest');
   }
 
-  protected onAfterShow(msg: Message) {
+  protected onAfterShow(msg: Message): void {
     super.onAfterShow(msg);
     this.messages.push(msg);
     this.methods.push('onAfterShow');
   }
 
-  protected onBeforeHide(msg: Message) {
+  protected onBeforeHide(msg: Message): void {
     super.onBeforeHide(msg);
     this.messages.push(msg);
     this.methods.push('onBeforeHide');
   }
 
-  protected onAfterAttach(msg: Message) {
+  protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.messages.push(msg);
     this.methods.push('onAfterAttach');
   }
 
-  protected onBeforeDetach(msg: Message) {
+  protected onBeforeDetach(msg: Message): void {
     super.onBeforeDetach(msg);
     this.messages.push(msg);
     this.methods.push('onBeforeDetach');
   }
 
-  protected onChildShown(msg: ChildMessage) {
+  protected onChildShown(msg: ChildMessage): void {
     super.onChildShown(msg);
     this.messages.push(msg);
     this.methods.push('onChildShown');
   }
 
-  protected onChildHidden(msg: ChildMessage) {
+  protected onChildHidden(msg: ChildMessage): void {
     super.onChildHidden(msg);
     this.messages.push(msg);
     this.methods.push('onChildHidden');
   }
 
-  protected onCloseRequest(msg: Message) {
+  protected onCloseRequest(msg: Message): void {
     super.onCloseRequest(msg);
     this.messages.push(msg);
     this.methods.push('onCloseRequest');
+  }
+
+  protected onChangeTitle(msg: ChangeTitleMessage): void {
+    super.onChangeTitle(msg);
+    this.messages.push(msg);
+    this.methods.push('onChangeTitle');
   }
 }
 
@@ -268,6 +275,58 @@ describe('phosphor-widget', () => {
         Widget.hiddenProperty.set(widget, true);
         expect(widget.messages.indexOf('before-hide')).to.not.be(-1);
         detachWidget(widget);
+      });
+
+    });
+
+    describe('.titleProperty', () => {
+
+      it('should be a property descriptor', () => {
+        expect(Widget.titleProperty instanceof Property).to.be(true);
+      });
+
+      it('should default to an empty string', () => {
+        var widget = new Widget();
+        expect(Widget.titleProperty.get(widget)).to.be('');
+      });
+
+    });
+
+    describe('.titleIconProperty', () => {
+
+      it('should be a property descriptor', () => {
+        expect(Widget.titleIconProperty instanceof Property).to.be(true);
+      });
+
+      it('should default to an empty string', () => {
+        var widget = new Widget();
+        expect(Widget.titleIconProperty.get(widget)).to.be('');
+      });
+
+    });
+
+    describe('.titleEditableHintProperty', () => {
+
+      it('should be a property descriptor', () => {
+        expect(Widget.titleEditableHintProperty instanceof Property).to.be(true);
+      });
+
+      it('should default to `false`', () => {
+        var widget = new Widget();
+        expect(Widget.titleEditableHintProperty.get(widget)).to.be(false);
+      });
+
+    });
+
+    describe('.closableHintProperty', () => {
+
+      it('should be a property descriptor', () => {
+        expect(Widget.closableHintProperty instanceof Property).to.be(true);
+      });
+
+      it('should default to `false`', () => {
+        var widget = new Widget();
+        expect(Widget.closableHintProperty.get(widget)).to.be(false);
       });
 
     });
@@ -418,6 +477,54 @@ describe('phosphor-widget', () => {
         expect(Widget.hiddenProperty.get(widget)).to.be(true);
         Widget.hiddenProperty.set(widget, false);
         expect(widget.hidden).to.be(false);
+      });
+
+    });
+
+    describe('#title', () => {
+
+      it('should be a pure delegate to the `titleProperty`', () => {
+        var widget = new Widget();
+        widget.title = 'Foo';
+        expect(Widget.titleProperty.get(widget)).to.be('Foo');
+        Widget.titleProperty.set(widget, 'Bar');
+        expect(widget.title).to.be('Bar');
+      });
+
+    });
+
+    describe('#titleIcon', () => {
+
+      it('should be a pure delegate to the `titleIconProperty`', () => {
+        var widget = new Widget();
+        widget.titleIcon = 'fa fa-close';
+        expect(Widget.titleIconProperty.get(widget)).to.be('fa fa-close');
+        Widget.titleIconProperty.set(widget, 'fa fa-open');
+        expect(widget.titleIcon).to.be('fa fa-open');
+      });
+
+    });
+
+    describe('#titleEditableHint', () => {
+
+      it('should be a pure delegate to the `titleEditableHintProperty`', () => {
+        var widget = new Widget();
+        widget.titleEditableHint = true;
+        expect(Widget.titleEditableHintProperty.get(widget)).to.be(true);
+        Widget.titleEditableHintProperty.set(widget, false);
+        expect(widget.titleEditableHint).to.be(false);
+      });
+
+    });
+
+    describe('#closableHint', () => {
+
+      it('should be a pure delegate to the `closableHintProperty`', () => {
+        var widget = new Widget();
+        widget.closableHint = true;
+        expect(Widget.closableHintProperty.get(widget)).to.be(true);
+        Widget.closableHintProperty.set(widget, false);
+        expect(widget.closableHint).to.be(false);
       });
 
     });
@@ -1722,6 +1829,39 @@ describe('phosphor-widget', () => {
 
     });
 
+    describe('#onChangeTitle', () => {
+
+      it('should be invoked on a `change-title`', () => {
+        var widget = new VerboseWidget();
+        sendMessage(widget, new ChangeTitleMessage('Foo'));
+        expect(widget.methods[0]).to.be('onChangeTitle');
+      });
+
+      context('`msg` parameter', () => {
+
+        it('should be a `ChangeTitleMessage`', () => {
+          var widget = new VerboseWidget();
+          sendMessage(widget, new ChangeTitleMessage('Foo'));
+          expect(widget.messages[0] instanceof ChangeTitleMessage).to.be(true);
+        });
+
+        it('should have a `type` of `change-title`', () => {
+          var widget = new VerboseWidget();
+          sendMessage(widget, new ChangeTitleMessage('Foo'));
+          expect(widget.messages[0].type).to.be('change-title');
+        });
+
+      });
+
+      it('should update the widget title by default', () => {
+        var widget = new Widget();
+        expect(widget.title).to.be('');
+        sendMessage(widget, new ChangeTitleMessage('Foo'));
+        expect(widget.title).to.be('Foo');
+      });
+
+    });
+
     context('message propagation', () => {
 
       it('should propagate `after-attach` to all descendants', () => {
@@ -2039,6 +2179,38 @@ describe('phosphor-widget', () => {
       it('should be a read-only property', () => {
         var msg = new ResizeMessage(100, 200);
         expect(() => { msg.height = 200; }).to.throwError();
+      });
+
+    });
+
+  });
+
+  describe('ChangeTitleMessage', () => {
+
+    describe('#constructor()', () => {
+
+      it('should accept a title', () => {
+        var msg = new ChangeTitleMessage('Foo');
+        expect(msg instanceof ChangeTitleMessage).to.be(true);
+      });
+
+      it('should have type `change-title`', () => {
+        var msg = new ChangeTitleMessage('Foo');
+        expect(msg.type).to.be('change-title');
+      });
+
+    });
+
+    describe('#title', () => {
+
+      it('should be the title passed to the constructor', () => {
+        var msg = new ChangeTitleMessage('Foo');
+        expect(msg.title).to.be('Foo');
+      });
+
+      it('should be a read-only property', () => {
+        var msg = new ChangeTitleMessage('Foo');
+        expect(() => { msg.title = 'Bar'; }).to.throwError();
       });
 
     });


### PR DESCRIPTION
This adds a few new properties to the base `Widget` class: `title`, `icon`, and `closable`. It also adds a `'change-title'` message type to allow input widgets to request a title change for a widget without directly setting the property, and thus avoiding feedback loops.

One outstanding question: do we want a `titleEditable` property to allow a widget to specify whether its title is editable via user interation?

Pinging @ellisonbg, @jasongrout, @blink1073, @dwillmer, @afshin, @sylvaincorlay